### PR TITLE
Document golang backend for rust rewrite

### DIFF
--- a/rekvm/rekvm/src/terminal.rs
+++ b/rekvm/rekvm/src/terminal.rs
@@ -1,0 +1,15 @@
+use anyhow::Result;
+
+/// Trait for PTY (pseudo terminal) abstraction
+pub trait Pty: Send + Sync {
+    fn read(&self, buf: &mut [u8]) -> Result<usize>;
+    fn write(&self, data: &[u8]) -> Result<usize>;
+    fn set_window_size(&self, size: &TerminalSize) -> Result<()>;
+}
+
+/// Trait for DataChannel abstraction
+pub trait DataChannel: Send + Sync {
+    fn send(&self, data: &[u8]) -> Result<()>;
+    fn close(&self) -> Result<()>;
+    fn id(&self) -> u16;
+}


### PR DESCRIPTION
Add `Pty` and `DataChannel` traits to abstract terminal I/O, improving testability and modularity for the Rust rewrite.

This PR introduces an abstraction layer for PTY and WebRTC DataChannel functionalities. This is a foundational step towards enabling dependency injection and mock testing, which are crucial for verifying business logic independently and ensuring the Rust implementation accurately matches the Go version's behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-10df3927-ff12-40e8-88f2-53e91835ac35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10df3927-ff12-40e8-88f2-53e91835ac35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

