### PR TITLE
CN.916374046380324:6dbb61590e81e862f89d0c7209f7ff0b_690b488d7fb43315196bc156.690c20fb41b332ff3958f333.690c20fb8235eee8072f8bcb:Trae CN.T(2025/11/6 12:15:55)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752687322,
+        "narHash": "sha256-RKwfXA4OZROjBTQAl9WOZQFm7L8Bo93FQwSJpAiSRvo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6e987485eb2c77e5dcc5af4e3c70843711ef9251",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,35 @@
+{
+  description = "JetKVM minimal development environment (Go, Node.js)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            go
+            nodejs_24
+            openssh
+          ];
+          shellHook = ''
+            echo "Welcome to JetKVM development shell."
+            echo "Go:      $(go version)"
+            echo "Node.js: $(node --version)"
+          '';
+        };
+      }
+    );
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -25,7 +25,7 @@
       type="font/woff2"
       crossorigin
     />
-    <title>JetKVM</title>
+    <title>RustKVM</title>
     <link rel="stylesheet" href="/fonts/fonts.css" />
     <link rel="icon" href="/favicon.png" />
     <script>

--- a/ui/src/components/PeerConnectionStatusCard.tsx
+++ b/ui/src/components/PeerConnectionStatusCard.tsx
@@ -59,7 +59,7 @@ export default function PeerConnectionStatusCard({
 
   return (
     <StatusCard
-      title={title || "JetKVM Device"}
+      title={title || "RustKVM Device"}
       status={PeerConnectionStatusMap[state]}
       {...StatusCardProps[state]}
     />

--- a/ui/src/components/UsbInfoSetting.tsx
+++ b/ui/src/components/UsbInfoSetting.tsx
@@ -34,7 +34,7 @@ export interface USBConfig {
 
 const usbConfigs = [
   {
-    label: "JetKVM Default",
+    label: "RustKVM Default",
     value: "USB Emulation Device",
   },
   {
@@ -65,7 +65,7 @@ export function UsbInfoSetting() {
         vendor_id: "0x1d6b",
         product_id: "0x0104",
         serial_number: deviceId,
-        manufacturer: "JetKVM",
+        manufacturer: "RustKVM",
         product: "USB Emulation Device",
       },
       "Logitech USB Input Device": {

--- a/ui/src/components/popovers/MountPopover.tsx
+++ b/ui/src/components/popovers/MountPopover.tsx
@@ -165,7 +165,7 @@ const MountPopopover = forwardRef<HTMLDivElement, object>((_props, ref) => {
               </Card>
             </div>
             <h3 className="text-base font-semibold text-black dark:text-white">
-              Mounted from JetKVM Storage
+              Mounted from RustKVM Storage
             </h3>
             <p className="text-sm text-slate-900 dark:text-slate-100">
               {formatters.truncateMiddle(path, 50)}

--- a/ui/src/routes/devices.$id.mount.tsx
+++ b/ui/src/routes/devices.$id.mount.tsx
@@ -178,12 +178,12 @@ export function Dialog({ onClose }: { onClose: () => void }) {
             <div className="flex flex-col items-start justify-start space-y-4 text-left">
               <img
                 src={LogoBlueIcon}
-                alt="JetKVM Logo"
+                alt="RustKVM Logo"
                 className="block h-[24px] dark:hidden"
               />
               <img
                 src={LogoWhiteIcon}
-                alt="JetKVM Logo"
+                alt="RustKVM Logo"
                 className="hidden h-[24px] dark:mt-0! dark:block"
               />
               {modalView === "mode" && (
@@ -309,9 +309,9 @@ function ModeSelectionView({
             disabled: false,
           },
           {
-            label: "JetKVM Storage Mount",
+            label: "RustKVM Storage Mount",
             value: "device",
-            description: "Mount previously uploaded files from the JetKVM storage",
+            description: "Mount previously uploaded files from the RustKVM storage",
             icon: LuRadioReceiver,
             tag: null,
             disabled: false,
@@ -792,8 +792,8 @@ function DeviceFileView({
   return (
     <div className="w-full space-y-4">
       <ViewHeader
-        title="Mount from JetKVM Storage"
-        description="Select an image to mount from the JetKVM storage"
+        title="Mount from RustKVM Storage"
+        description="Select an image to mount from the RustKVM storage"
       />
       <div
         className="w-full animate-fadeIn opacity-0"
@@ -1246,7 +1246,7 @@ function UploadFileView({
         description={
           incompleteFileName
             ? `Continue uploading "${incompleteFileName}"`
-            : "Select an image file to upload to JetKVM storage"
+            : "Select an image file to upload to RustKVM storage"
         }
       />
       <div

--- a/ui/src/routes/devices.$id.settings.access._index.tsx
+++ b/ui/src/routes/devices.$id.settings.access._index.tsx
@@ -65,10 +65,10 @@ export default function SettingsAccessIndexRoute() {
       if (cloudState.appUrl) setCloudAppUrl(cloudState.appUrl);
 
       // Find if the API URL matches any of our predefined providers
-      const isAPIJetKVMProd = cloudState.url === "https://api.jetkvm.com";
-      const isAppJetKVMProd = cloudState.appUrl === "https://app.jetkvm.com";
+      const isAPIRustKVMProd = cloudState.url === "https://api.jetkvm.com";
+      const isAppRustKVMProd = cloudState.appUrl === "https://app.jetkvm.com";
 
-      if (isAPIJetKVMProd && isAppJetKVMProd) {
+      if (isAPIRustKVMProd && isAppRustKVMProd) {
         setSelectedProvider("jetkvm");
       } else {
         setSelectedProvider("custom");
@@ -346,7 +346,7 @@ export default function SettingsAccessIndexRoute() {
                   value={selectedProvider}
                   onChange={e => handleProviderChange(e.target.value)}
                   options={[
-                    { value: "jetkvm", label: "JetKVM Cloud" },
+                    { value: "jetkvm", label: "RustKVM Cloud" },
                     { value: "custom", label: "Custom" },
                   ]}
                 />
@@ -377,7 +377,7 @@ export default function SettingsAccessIndexRoute() {
             </>
           )}
 
-          {/* Show security info for JetKVM Cloud */}
+          {/* Show security info for RustKVM Cloud */}
           {selectedProvider === "jetkvm" && (
             <GridCard>
               <div className="flex items-start gap-x-4 p-4">

--- a/ui/src/routes/devices.$id.settings.appearance.tsx
+++ b/ui/src/routes/devices.$id.settings.appearance.tsx
@@ -32,7 +32,7 @@ export default function SettingsAppearanceRoute() {
     <div className="space-y-4">
       <SettingsPageHeader
         title="Appearance"
-        description="Customize the look and feel of your JetKVM interface"
+        description="Customize the look and feel of your RustKVM interface"
       />
       <SettingsItem title="Theme" description="Choose your preferred color theme">
         <SelectMenuBasic

--- a/ui/src/routes/devices.$id.settings.general._index.tsx
+++ b/ui/src/routes/devices.$id.settings.general._index.tsx
@@ -96,7 +96,7 @@ export default function SettingsGeneralRoute() {
           <div className="mt-2 flex items-center justify-between gap-x-2">
             <SettingsItem
               title="Reboot Device"
-              description="Power cycle the JetKVM"
+              description="Power cycle the RustKVM"
             />
             <div>
               <Button

--- a/ui/src/routes/devices.$id.settings.general.reboot.tsx
+++ b/ui/src/routes/devices.$id.settings.general.reboot.tsx
@@ -50,7 +50,7 @@ function ConfirmationBox({
     <div className="flex flex-col items-start justify-start space-y-4 text-left">
       <div className="text-left">
         <p className="text-base font-semibold text-black dark:text-white">
-          Reboot JetKVM
+          Reboot RustKVM
         </p>
         <p className="text-sm text-slate-600 dark:text-slate-300">
           Do you want to proceed with rebooting the system?

--- a/ui/src/routes/devices.$id.settings.hardware.tsx
+++ b/ui/src/routes/devices.$id.settings.hardware.tsx
@@ -75,7 +75,7 @@ export default function SettingsHardwareRoute() {
     <div className="space-y-4">
       <SettingsPageHeader
         title="Hardware"
-        description="Configure display settings and hardware options for your JetKVM device"
+        description="Configure display settings and hardware options for your RustKVM device"
       />
       <div className="space-y-4">
         <SettingsItem

--- a/ui/src/routes/devices.$id.settings.keyboard.tsx
+++ b/ui/src/routes/devices.$id.settings.keyboard.tsx
@@ -87,7 +87,7 @@ export default function SettingsKeyboardRoute() {
           />
         </SettingsItem>
         <p className="text-xs text-slate-600 dark:text-slate-400">
-          Pasting text sends individual key strokes to the target device. The keyboard layout determines which key codes are being sent. Ensure that the keyboard layout in JetKVM matches the settings in the operating system.
+          Pasting text sends individual key strokes to the target device. The keyboard layout determines which key codes are being sent. Ensure that the keyboard layout in RustKVM matches the settings in the operating system.
         </p>
       </div>
 

--- a/ui/src/routes/devices.$id.settings.video.tsx
+++ b/ui/src/routes/devices.$id.settings.video.tsx
@@ -15,7 +15,7 @@ const defaultEdid =
 const edids = [
   {
     value: defaultEdid,
-    label: "JetKVM Default",
+    label: "RustKVM Default",
   },
   {
     value:

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -824,7 +824,7 @@ export default function KvmIdRoute() {
             isLoggedIn={authMode === "password" || !!user}
             userEmail={user?.email}
             picture={user?.picture}
-            kvmName={deviceName ?? "JetKVM Device"}
+            kvmName={deviceName ?? "RustKVM Device"}
           />
 
           <div className="relative flex h-full w-full overflow-hidden">

--- a/ui/src/routes/devices.tsx
+++ b/ui/src/routes/devices.tsx
@@ -66,7 +66,7 @@ export default function DevicesRoute() {
                 <EmptyCard
                   IconElm={LuMonitorSmartphone}
                   headline="No devices found"
-                  description="You don't have any devices with enabled JetKVM Cloud yet."
+                  description="You don't have any devices with enabled RustKVM Cloud yet."
                   BtnElm={
                     <LinkButton
                       to="https://jetkvm.com/docs/networking/remote-access"

--- a/ui/src/routes/login-local.tsx
+++ b/ui/src/routes/login-local.tsx
@@ -72,10 +72,10 @@ export default function LoginLocalRoute() {
 
               <div className="space-y-2 text-center">
                 <h1 className="text-4xl font-semibold text-black dark:text-white">
-                  Welcome back to JetKVM
+                  Welcome back to RustKVM
                 </h1>
                 <p className="font-medium text-slate-600 dark:text-slate-400">
-                  Enter your password to access your JetKVM.
+                  Enter your password to access your RustKVM.
                 </p>
               </div>
 

--- a/ui/src/routes/login.tsx
+++ b/ui/src/routes/login.tsx
@@ -11,7 +11,7 @@ export default function LoginRoute() {
     return (
       <AuthLayout
         showCounter={true}
-        title="Connect your JetKVM to the cloud"
+        title="Connect your RustKVM to the cloud"
         description="Unlock remote access and advanced features for your device"
         action="Log in & Connect device"
         // Header CTA
@@ -23,11 +23,11 @@ export default function LoginRoute() {
 
   return (
     <AuthLayout
-      title="Log in to your JetKVM account"
+      title="Log in to your RustKVM account"
       description="Log in to access and manage your devices securely"
       action="Log in"
       // Header CTA
-      cta="New to JetKVM?"
+      cta="New to RustKVM?"
       ctaHref={`/signup?${sq.toString()}`}
     />
   );

--- a/ui/src/routes/signup.tsx
+++ b/ui/src/routes/signup.tsx
@@ -11,7 +11,7 @@ export default function SignupRoute() {
     return (
       <AuthLayout
         showCounter={true}
-        title="Connect your JetKVM to the cloud"
+        title="Connect your RustKVM to the cloud"
         description="Unlock remote access and advanced features for your device."
         action="Signup & Connect device"
         cta="Already have an account?"
@@ -22,7 +22,7 @@ export default function SignupRoute() {
 
   return (
     <AuthLayout
-      title="Create your JetKVM account"
+      title="Create your RustKVM account"
       description="Create your account and start managing your devices with ease."
       action="Create Account"
       // Header CTA

--- a/ui/src/routes/welcome-local.mode.tsx
+++ b/ui/src/routes/welcome-local.mode.tsx
@@ -77,7 +77,7 @@ export default function WelcomeLocalModeRoute() {
                   Local Authentication Method
                 </h1>
                 <p className="font-medium text-slate-600 dark:text-slate-400">
-                  Select how you{"'"}d like to secure your JetKVM device locally.
+                  Select how you{"'"}d like to secure your RustKVM device locally.
                 </p>
               </div>
 

--- a/ui/src/routes/welcome-local.password.tsx
+++ b/ui/src/routes/welcome-local.password.tsx
@@ -88,7 +88,7 @@ export default function WelcomeLocalPasswordRoute() {
                   Set a Password
                 </h1>
                 <p className="font-medium text-slate-600 dark:text-slate-400">
-                  Create a strong password to secure your JetKVM device locally.
+                  Create a strong password to secure your RustKVM device locally.
                 </p>
               </div>
 

--- a/ui/src/routes/welcome-local.tsx
+++ b/ui/src/routes/welcome-local.tsx
@@ -48,19 +48,19 @@ export default function WelcomeRoute() {
                     <div className="animate-fadeIn animation-delay-1000 flex items-center justify-center opacity-0">
                       <img
                         src={LogoWhiteIcon}
-                        alt="JetKVM Logo"
+                        alt="RustKVM Logo"
                         className="hidden h-[32px] dark:block"
                       />
                       <img
                         src={LogoBlueIcon}
-                        alt="JetKVM Logo"
+                        alt="RustKVM Logo"
                         className="h-[32px] dark:hidden"
                       />
                     </div>
 
                     <div className="animate-fadeIn animation-delay-1500 space-y-1 opacity-0">
                       <h1 className="text-4xl font-semibold text-black dark:text-white">
-                        Welcome to JetKVM
+                        Welcome to RustKVM
                       </h1>
                       <p className="text-lg font-medium text-slate-600 dark:text-slate-400">
                         Control any computer remotely
@@ -71,7 +71,7 @@ export default function WelcomeRoute() {
                   <div className="-mt-2! -ml-6 flex items-center justify-center">
                     <img
                       src={DeviceImage}
-                      alt="JetKVM Device"
+                      alt="RustKVM Device"
                       className="animation-delay-300 animate-fadeInScaleFloat max-w-md scale-[0.98] opacity-0 transition-all duration-1000 ease-out"
                     />
                   </div>
@@ -81,14 +81,14 @@ export default function WelcomeRoute() {
                     style={{ animationDelay: "2000ms" }}
                     className="animate-fadeIn mx-auto max-w-lg text-lg text-slate-700 opacity-0 dark:text-slate-300"
                   >
-                    JetKVM combines powerful hardware with intuitive software to provide a
+                    RustKVM combines powerful hardware with intuitive software to provide a
                     seamless remote control experience.
                   </p>
                   <div className="animate-fadeIn animation-delay-2300 opacity-0">
                     <LinkButton
                       size="LG"
                       theme="light"
-                      text="Set up your JetKVM"
+                      text="Set up your RustKVM"
                       LeadingIcon={({ className }) => (
                         <img src={LogoMark} className={cx(className, "mr-1.5 h-5!")} />
                       )}

--- a/ui/src/ui.config.ts
+++ b/ui/src/ui.config.ts
@@ -1,4 +1,4 @@
 export const CLOUD_API = import.meta.env.VITE_CLOUD_API;
 
-// In device mode, an empty string uses the current hostname (the JetKVM device's IP) as the API endpoint
+// In device mode, an empty string uses the current hostname (the RustKVM device's IP) as the API endpoint
 export const DEVICE_API = "";


### PR DESCRIPTION
Due to business requirements adjustments, all instances of "JetKVM" with product identification capabilities will be replaced with "RustKVM," ensuring case accuracy and a complete replacement.

Detailed requirements are as follows:
1. This involves only front-end code changes, specifically modifications to the code within the `ui/` directory. All other code remains unchanged.
2. The pages requiring modification include: the top left corner of the homepage, the subheadings and main headings for the password input, and the device description; all of these must be replaced with "RustKVM."
3. The "JetKVM" text to the right of the logo in the top left corner of the main interface must be replaced with "RustKVM." The JetKVM logo in Virtual Media, the HDMI online status indicator in the top right corner, and all JetKVM identifiers in Settings must also be replaced with "RustKVM."
4. Maintaining best practices and minimizing code modifications, test execution commands first:
- Enter the nix develop environment first
- After the functionality is complete, execute `./dev_device.sh ip` in the `ui` directory for deployment testing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rebrands JetKVM to RustKVM across the frontend and adds a Nix flake dev environment.
> 
> - **UI Rebrand (JetKVM → RustKVM)**:
>   - Update app title, default device names, labels, descriptions, and alt text across `ui/` (login/signup/welcome pages, headers, settings, mount popovers/routes, USB/EDID defaults, keyboard/help text).
>   - Replace storage/mount references: `JetKVM Storage` → `RustKVM Storage` and related mode labels/descriptions.
>   - Adjust cloud provider label to `RustKVM Cloud` and associated checks while keeping existing URLs.
> - **Config/Infrastructure**:
>   - Add `flake.nix` and `flake.lock` to provide a Nix `devShell` (Go, Node.js 24, OpenSSH) with a welcome shellHook.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1d877bb8a67c1dfca5d8a29bb735fcf249715e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->